### PR TITLE
Fix #134 remove temporarly broadcast boot part

### DIFF
--- a/app/Providers/BroadcastServiceProvider.php
+++ b/app/Providers/BroadcastServiceProvider.php
@@ -19,8 +19,9 @@ class BroadcastServiceProvider extends ServiceProvider
         /*
          * Authenticate the user's personal channel...
          */
-        Broadcast::channel('App.User.{userId}', function ($user, $userId) {
-            return (int) $user->id === (int) $userId;
-        });
+        // TODO Uncomment this part if needed in the future
+        // Broadcast::channel('App.User.{userId}', function ($user, $userId) {
+        //     return (int) $user->id === (int) $userId;
+        // });
     }
 }


### PR DESCRIPTION
This part isn't used for now. Uncomment for the next time it's needed.